### PR TITLE
fix: 头像上传问题

### DIFF
--- a/api/v1/user.go
+++ b/api/v1/user.go
@@ -4,7 +4,8 @@ import (
 	"mall/consts"
 	util "mall/pkg/utils"
 	"mall/service"
-
+	"mall/pkg/e"
+	"github.com/pkg/errors"
 	"github.com/gin-gonic/gin"
 )
 
@@ -45,6 +46,12 @@ func UserUpdate(c *gin.Context) {
 
 func UploadAvatar(c *gin.Context) {
 	file, fileHeader, _ := c.Request.FormFile("file")
+	if fileHeader == nil {
+		err := errors.New(e.GetMsg(e.ErrorUploadFile))
+	 	c.JSON(consts.IlleageRequest, ErrorResponse(err))
+	 	util.LogrusObj.Infoln(err)
+	 	return;
+	}
 	fileSize := fileHeader.Size
 	uploadAvatarService := service.UserService{}
 	chaim, _ := util.ParseToken(c.GetHeader("Authorization"))

--- a/pkg/utils/upload.go
+++ b/pkg/utils/upload.go
@@ -64,7 +64,7 @@ func DirExistOrNot(fileAddr string) bool {
 
 // CreateDir 创建文件夹
 func CreateDir(dirName string) bool {
-	err := os.MkdirAll(dirName, 7550)
+	err := os.MkdirAll(dirName, 0755)
 	if err != nil {
 		log.Println(err)
 		return false


### PR DESCRIPTION
1.上传头像时参数错误导致服务端panic,测试脚本如下:
curl --location --request POST http://localhost:3000/api/v1/avatar   --header Authorization:eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwidXNlcm5hbWUiOiJ1b3MiLCJhdXRob3JpdHkiOjAsImV4cCI6MTY3ODc4NTUzOSwiaXNzIjoibWFsbCJ9.N5qnhSoN65otzZ5_tCjj64OuImHNgKJ_H4q-Uyzi8zI   --form file=/home/test/Desktop/my_photo.png

2.上传头像时，创建本地目录权限错误，导致客户端无法下载头像

Log: